### PR TITLE
Add `overflow: hidden` to body

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -19,7 +19,7 @@ export default function RootLayout({
       className="bg-zinc-50 dark:bg-zinc-950 text-zinc-800 dark:text-zinc-300 h-full w-full"
     >
       <body
-        className={`${inter.className} h-full w-full flex items-start md:items-center justify-center`}
+        className={`${inter.className} h-full w-full flex items-start md:items-center justify-center overflow-hidden`}
       >
         {children}
       </body>


### PR DESCRIPTION
Fixes horizontal scrolling caused by blurred shapes

<img width="516" alt="Screenshot 2023-05-18 at 11 05 47 PM" src="https://github.com/zachbharris/Shrtn/assets/12797652/e105c4a7-e82f-4a31-9431-c43aeff1d3ac">